### PR TITLE
fix: free form object deserialization

### DIFF
--- a/dart-templates/serialization/native/class.mustache
+++ b/dart-templates/serialization/native/class.mustache
@@ -165,7 +165,17 @@ class {{{classname}}} {{#interfaces}}{{#-first}}implements {{/-first}}{{.}}{{^-l
     {{#isReadOnly}}final {{/isReadOnly}}Map<String, Object?>{{^required}}?{{/required}} {{{name}}};
   {{/isFreeFormObject}}
   {{^isFreeFormObject}}
-    {{#isReadOnly}}final {{/isReadOnly}}{{{datatypeWithEnum}}}{{^required}}?{{/required}} {{{name}}};
+    {{#isArray}}
+      {{#items.isFreeFormObject}}
+        {{#isReadOnly}}final {{/isReadOnly}}List<Map<String, Object?>>{{^required}}?{{/required}} {{{name}}};
+      {{/items.isFreeFormObject}}
+      {{^items.isFreeFormObject}}
+        {{#isReadOnly}}final {{/isReadOnly}}{{{datatypeWithEnum}}}{{^required}}?{{/required}} {{{name}}};
+      {{/items.isFreeFormObject}}
+    {{/isArray}}
+    {{^isArray}}
+      {{#isReadOnly}}final {{/isReadOnly}}{{{datatypeWithEnum}}}{{^required}}?{{/required}} {{{name}}};
+    {{/isArray}}
   {{/isFreeFormObject}}
 
   {{/vars}}

--- a/dart-templates/serialization/native/class.mustache
+++ b/dart-templates/serialization/native/class.mustache
@@ -46,7 +46,7 @@ class {{{classname}}} {{#interfaces}}{{#-first}}implements {{/-first}}{{.}}{{^-l
         {{^items.isArray}}
         {{{name}}}: 
           {{#items.isFreeFormObject}}
-          json[r'{{{baseName}}}'] == null ? null : List<{{{items.dataType}}}>.from(json[r'{{{baseName}}}']),
+          json[r'{{{baseName}}}'] == null ? null : List<Map<String, Object?>>.from(json[r'{{{baseName}}}']),
           {{/items.isFreeFormObject}}
           {{^items.isFreeFormObject}}
           {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']),
@@ -79,7 +79,7 @@ class {{{classname}}} {{#interfaces}}{{#-first}}implements {{/-first}}{{.}}{{^-l
               {{items.complexType}}.mapFromJson(json[r'{{{baseName}}}']),
             {{/items.isModel}}
             {{^items.isModel}}
-              json[r'{{{baseName}}}'] == null ? null : {{{dataType}}}.from(json[r'{{{baseName}}}']),
+              json[r'{{{baseName}}}'] == null ? null : Map<String, Object?>.from(json[r'{{{baseName}}}']),
             {{/items.isModel}}
           {{/items.isMap}}
           {{/items.isArray}}
@@ -128,7 +128,7 @@ class {{{classname}}} {{#interfaces}}{{#-first}}implements {{/-first}}{{.}}{{^-l
               {{#isFreeFormObject}}
                 {{{name}}}: json[r'{{{baseName}}}'] == null ?
                 null :
-                Map<String, Object>.from(json[r'{{{baseName}}}']),
+                Map<String, Object?>.from(json[r'{{{baseName}}}']),
               {{/isFreeFormObject}}
               {{^isFreeFormObject}}
                 {{#isFloat}}
@@ -162,7 +162,7 @@ class {{{classname}}} {{#interfaces}}{{#-first}}implements {{/-first}}{{.}}{{^-l
     {{/maximum}}
   {{/isEnum}}
   {{#isFreeFormObject}}
-    {{#isReadOnly}}final {{/isReadOnly}}Map<String, Object>{{^required}}?{{/required}} {{{name}}};
+    {{#isReadOnly}}final {{/isReadOnly}}Map<String, Object?>{{^required}}?{{/required}} {{{name}}};
   {{/isFreeFormObject}}
   {{^isFreeFormObject}}
     {{#isReadOnly}}final {{/isReadOnly}}{{{datatypeWithEnum}}}{{^required}}?{{/required}} {{{name}}};

--- a/dart-v3/lib/model/integration_integration_read.dart
+++ b/dart-v3/lib/model/integration_integration_read.dart
@@ -35,14 +35,14 @@ class IntegrationIntegrationRead {
     return IntegrationIntegrationRead(
       inputs: json[r'inputs'] == null
           ? null
-          : Map<String, Object>.from(json[r'inputs']),
+          : Map<String, Object?>.from(json[r'inputs']),
       id: json[r'id'],
       createdAt: createdAt,
       updatedAt: updatedAt,
     );
   }
 
-  Map<String, Object>? inputs;
+  Map<String, Object?>? inputs;
 
   /// The resource identifier.
   final String? id;

--- a/dart-v3/lib/model/integration_jsonhal_integration_read.dart
+++ b/dart-v3/lib/model/integration_jsonhal_integration_read.dart
@@ -38,7 +38,7 @@ class IntegrationJsonhalIntegrationRead {
       links: AssetTypeJsonhalReadLinks.fromJson(json[r'_links']),
       inputs: json[r'inputs'] == null
           ? null
-          : Map<String, Object>.from(json[r'inputs']),
+          : Map<String, Object?>.from(json[r'inputs']),
       id: json[r'id'],
       createdAt: createdAt,
       updatedAt: updatedAt,
@@ -47,7 +47,7 @@ class IntegrationJsonhalIntegrationRead {
 
   AssetTypeJsonhalReadLinks? links;
 
-  Map<String, Object>? inputs;
+  Map<String, Object?>? inputs;
 
   /// The resource identifier.
   final String? id;

--- a/dart-v3/lib/model/integration_link_create_link_command_write.dart
+++ b/dart-v3/lib/model/integration_link_create_link_command_write.dart
@@ -26,22 +26,22 @@ class IntegrationLinkCreateLinkCommandWrite {
     return IntegrationLinkCreateLinkCommandWrite(
       data: json[r'data'] == null
           ? null
-          : Map<String, Object>.from(json[r'data']),
+          : Map<String, Object?>.from(json[r'data']),
       integration: json[r'integration'],
       metadata: json[r'metadata'] == null
           ? null
-          : Map<String, Object>.from(json[r'metadata']),
+          : Map<String, Object?>.from(json[r'metadata']),
       name: json[r'name'],
       source_: json[r'source'],
       target: json[r'target'],
     );
   }
 
-  Map<String, Object>? data;
+  Map<String, Object?>? data;
 
   String integration;
 
-  Map<String, Object>? metadata;
+  Map<String, Object?>? metadata;
 
   String? name;
 

--- a/dart-v3/lib/model/integration_link_edit_link_command_write.dart
+++ b/dart-v3/lib/model/integration_link_edit_link_command_write.dart
@@ -25,10 +25,10 @@ class IntegrationLinkEditLinkCommandWrite {
     return IntegrationLinkEditLinkCommandWrite(
       data: json[r'data'] == null
           ? null
-          : Map<String, Object>.from(json[r'data']),
+          : Map<String, Object?>.from(json[r'data']),
       metadata: json[r'metadata'] == null
           ? null
-          : Map<String, Object>.from(json[r'metadata']),
+          : Map<String, Object?>.from(json[r'metadata']),
       name: json[r'name'],
       state:
           IntegrationLinkEditLinkCommandWriteStateEnum.fromJson(json[r'state']),
@@ -36,9 +36,9 @@ class IntegrationLinkEditLinkCommandWrite {
     );
   }
 
-  Map<String, Object>? data;
+  Map<String, Object?>? data;
 
-  Map<String, Object>? metadata;
+  Map<String, Object?>? metadata;
 
   String? name;
 

--- a/dart-v3/lib/model/integration_link_jsonhal_read.dart
+++ b/dart-v3/lib/model/integration_link_jsonhal_read.dart
@@ -42,10 +42,10 @@ class IntegrationLinkJsonhalRead {
       links: AssetTypeJsonhalReadLinks.fromJson(json[r'_links']),
       data: json[r'data'] == null
           ? null
-          : Map<String, Object>.from(json[r'data']),
+          : Map<String, Object?>.from(json[r'data']),
       metadata: json[r'metadata'] == null
           ? null
-          : Map<String, Object>.from(json[r'metadata']),
+          : Map<String, Object?>.from(json[r'metadata']),
       name: json[r'name'],
       source_: json[r'source'],
       state: IntegrationLinkJsonhalReadStateEnum.fromJson(json[r'state']),
@@ -58,9 +58,9 @@ class IntegrationLinkJsonhalRead {
 
   AssetTypeJsonhalReadLinks? links;
 
-  Map<String, Object>? data;
+  Map<String, Object?>? data;
 
-  Map<String, Object>? metadata;
+  Map<String, Object?>? metadata;
 
   String? name;
 

--- a/dart-v3/lib/model/integration_link_read.dart
+++ b/dart-v3/lib/model/integration_link_read.dart
@@ -40,10 +40,10 @@ class IntegrationLinkRead {
     return IntegrationLinkRead(
       data: json[r'data'] == null
           ? null
-          : Map<String, Object>.from(json[r'data']),
+          : Map<String, Object?>.from(json[r'data']),
       metadata: json[r'metadata'] == null
           ? null
-          : Map<String, Object>.from(json[r'metadata']),
+          : Map<String, Object?>.from(json[r'metadata']),
       name: json[r'name'],
       source_: json[r'source'],
       state: IntegrationLinkReadStateEnum.fromJson(json[r'state']),
@@ -54,9 +54,9 @@ class IntegrationLinkRead {
     );
   }
 
-  Map<String, Object>? data;
+  Map<String, Object?>? data;
 
-  Map<String, Object>? metadata;
+  Map<String, Object?>? metadata;
 
   String? name;
 

--- a/dart/lib/model/document.dart
+++ b/dart/lib/model/document.dart
@@ -45,7 +45,7 @@ class Document {
       links: DocumentLinks.fromJson(json[r'_links']),
       body: json[r'body'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'body']),
+          : List<Map<String, Object?>>.from(json[r'body']),
       createdAt: createdAt,
       file: DocumentFile.fromJson(json[r'file']),
       id: json[r'id'],
@@ -62,7 +62,7 @@ class Document {
 
   DocumentLinks? links;
 
-  List<Map<String, Object>>? body;
+  List<Map<String, Object?>>? body;
 
   final DateTime? createdAt;
 

--- a/dart/lib/model/document_embedded.dart
+++ b/dart/lib/model/document_embedded.dart
@@ -24,7 +24,7 @@ class DocumentEmbedded {
     return DocumentEmbedded(
       container: json[r'container'] == null
           ? null
-          : Map<String, Object>.from(json[r'container']),
+          : Map<String, Object?>.from(json[r'container']),
       createdBy: Person.fromJson(json[r'createdBy']),
       signers: Signer.listFromJson(json[r'signers']),
       stateTransitions: json[r'stateTransitions'] == null
@@ -34,7 +34,7 @@ class DocumentEmbedded {
     );
   }
 
-  Map<String, Object>? container;
+  Map<String, Object?>? container;
 
   Person? createdBy;
 

--- a/dart/lib/model/document_patch.dart
+++ b/dart/lib/model/document_patch.dart
@@ -24,7 +24,7 @@ class DocumentPatch {
     return DocumentPatch(
       body: json[r'body'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'body']),
+          : List<Map<String, Object?>>.from(json[r'body']),
       file: DocumentPatchFile.fromJson(json[r'file']),
       permission: DocumentPatchPermission.fromJson(json[r'permission']),
       text: json[r'text'],
@@ -32,7 +32,7 @@ class DocumentPatch {
     );
   }
 
-  List<Map<String, Object>>? body;
+  List<Map<String, Object?>>? body;
 
   DocumentPatchFile? file;
 

--- a/dart/lib/model/feedback.dart
+++ b/dart/lib/model/feedback.dart
@@ -48,7 +48,7 @@ class Feedback {
       id: json[r'id'],
       metadata: json[r'metadata'] == null
           ? null
-          : Map<String, Object>.from(json[r'metadata']),
+          : Map<String, Object?>.from(json[r'metadata']),
       public: json[r'public'],
       type: json[r'type'],
       updatedAt: updatedAt,
@@ -68,7 +68,7 @@ class Feedback {
 
   final String? id;
 
-  Map<String, Object>? metadata;
+  Map<String, Object?>? metadata;
 
   bool? public;
 

--- a/dart/lib/model/feedback_data.dart
+++ b/dart/lib/model/feedback_data.dart
@@ -35,7 +35,7 @@ class FeedbackData {
       geo: FeedbackDataGeo.fromJson(json[r'geo'])!,
       metadata: json[r'metadata'] == null
           ? null
-          : Map<String, Object>.from(json[r'metadata']),
+          : Map<String, Object?>.from(json[r'metadata']),
       priority: json[r'priority'],
       reporter: json[r'reporter'],
       visibility: FeedbackDataVisibilityEnum.fromJson(json[r'visibility'])!,
@@ -54,7 +54,7 @@ class FeedbackData {
 
   FeedbackDataGeo geo;
 
-  Map<String, Object>? metadata;
+  Map<String, Object?>? metadata;
 
   String? priority;
 

--- a/dart/lib/model/message_data.dart
+++ b/dart/lib/model/message_data.dart
@@ -21,12 +21,12 @@ class MessageData {
     return MessageData(
       text: json[r'text'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'text']),
+          : List<Map<String, Object?>>.from(json[r'text']),
       task: json[r'task'],
     );
   }
 
-  List<Map<String, Object>>? text;
+  List<Map<String, Object?>>? text;
 
   String task;
 

--- a/dart/lib/model/note.dart
+++ b/dart/lib/model/note.dart
@@ -40,7 +40,7 @@ class Note {
       id: json[r'id'],
       text: json[r'text'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'text']),
+          : List<Map<String, Object?>>.from(json[r'text']),
       type: json[r'type'],
       updatedAt: updatedAt,
     );
@@ -52,7 +52,7 @@ class Note {
 
   final String? id;
 
-  List<Map<String, Object>>? text;
+  List<Map<String, Object?>>? text;
 
   String? type;
 

--- a/dart/lib/model/note_patch.dart
+++ b/dart/lib/model/note_patch.dart
@@ -20,11 +20,11 @@ class NotePatch {
     return NotePatch(
       text: json[r'text'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'text']),
+          : List<Map<String, Object?>>.from(json[r'text']),
     );
   }
 
-  List<Map<String, Object>>? text;
+  List<Map<String, Object?>>? text;
 
   @override
   bool operator ==(Object other) {

--- a/dart/lib/model/run.dart
+++ b/dart/lib/model/run.dart
@@ -27,7 +27,7 @@ class Run {
       name: json[r'name'],
       result: json[r'result'] == null
           ? null
-          : Map<String, Object>.from(json[r'result']),
+          : Map<String, Object?>.from(json[r'result']),
       state: json[r'state'],
     );
   }
@@ -38,7 +38,7 @@ class Run {
 
   String? name;
 
-  Map<String, Object>? result;
+  Map<String, Object?>? result;
 
   String? state;
 

--- a/dart/lib/model/run_data.dart
+++ b/dart/lib/model/run_data.dart
@@ -23,22 +23,22 @@ class RunData {
     return RunData(
       event: json[r'event'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'event']),
+          : List<Map<String, Object?>>.from(json[r'event']),
       inputs: json[r'inputs'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'inputs']),
+          : List<Map<String, Object?>>.from(json[r'inputs']),
       outputs: json[r'outputs'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'outputs']),
+          : List<Map<String, Object?>>.from(json[r'outputs']),
       verbose: json[r'verbose'],
     );
   }
 
-  List<Map<String, Object>>? event;
+  List<Map<String, Object?>>? event;
 
-  List<Map<String, Object>>? inputs;
+  List<Map<String, Object?>>? inputs;
 
-  List<Map<String, Object>>? outputs;
+  List<Map<String, Object?>>? outputs;
 
   bool? verbose;
 

--- a/dart/lib/model/template.dart
+++ b/dart/lib/model/template.dart
@@ -39,14 +39,14 @@ class Template {
     return Template(
       body: json[r'body'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'body']),
+          : List<Map<String, Object?>>.from(json[r'body']),
       createdAt: createdAt,
       footer: json[r'footer'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'footer']),
+          : List<Map<String, Object?>>.from(json[r'footer']),
       header: json[r'header'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'header']),
+          : List<Map<String, Object?>>.from(json[r'header']),
       id: json[r'id'],
       name: json[r'name'],
       type: json[r'type'],
@@ -54,13 +54,13 @@ class Template {
     );
   }
 
-  List<Map<String, Object>>? body;
+  List<Map<String, Object?>>? body;
 
   final DateTime? createdAt;
 
-  List<Map<String, Object>>? footer;
+  List<Map<String, Object?>>? footer;
 
-  List<Map<String, Object>>? header;
+  List<Map<String, Object?>>? header;
 
   final String? id;
 

--- a/dart/lib/model/template_data.dart
+++ b/dart/lib/model/template_data.dart
@@ -25,24 +25,24 @@ class TemplateData {
     return TemplateData(
       body: json[r'body'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'body']),
+          : List<Map<String, Object?>>.from(json[r'body']),
       footer: json[r'footer'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'footer']),
+          : List<Map<String, Object?>>.from(json[r'footer']),
       header: json[r'header'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'header']),
+          : List<Map<String, Object?>>.from(json[r'header']),
       name: json[r'name'],
       organization: json[r'organization'],
       type: json[r'type'],
     );
   }
 
-  List<Map<String, Object>>? body;
+  List<Map<String, Object?>>? body;
 
-  List<Map<String, Object>>? footer;
+  List<Map<String, Object?>>? footer;
 
-  List<Map<String, Object>>? header;
+  List<Map<String, Object?>>? header;
 
   String name;
 

--- a/dart/lib/model/template_patch.dart
+++ b/dart/lib/model/template_patch.dart
@@ -24,23 +24,23 @@ class TemplatePatch {
     return TemplatePatch(
       body: json[r'body'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'body']),
+          : List<Map<String, Object?>>.from(json[r'body']),
       footer: json[r'footer'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'footer']),
+          : List<Map<String, Object?>>.from(json[r'footer']),
       header: json[r'header'] == null
           ? null
-          : List<Map<String, Object>>.from(json[r'header']),
+          : List<Map<String, Object?>>.from(json[r'header']),
       name: json[r'name'],
       type: json[r'type'],
     );
   }
 
-  List<Map<String, Object>>? body;
+  List<Map<String, Object?>>? body;
 
-  List<Map<String, Object>>? footer;
+  List<Map<String, Object?>>? footer;
 
-  List<Map<String, Object>>? header;
+  List<Map<String, Object?>>? header;
 
   String? name;
 


### PR DESCRIPTION
the generator set `AnyType` items type as `Object` without taking into account the field nullability. During the deserialization process their is a type cast error due to item being `_JsonMap` type which would worked with `Map<String, dynamic>` / `Map<String, Object?>`

useful links if we want to contribute to the project
https://github.com/OpenAPITools/openapi-generator/blob/v7.0.1/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java#L162
https://github.com/OpenAPITools/openapi-generator/blob/v7.0.1/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java#L527
https://github.com/OpenAPITools/openapi-generator/blob/v7.0.1/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java#L550